### PR TITLE
Fix routes to use new agents

### DIFF
--- a/backend/agents/agent_router.py
+++ b/backend/agents/agent_router.py
@@ -1,16 +1,33 @@
 from backend.agents.tone_agent import calibrate_tone
 from backend.agents.structure_validator import validate_structure
 from backend.agents.metadata_agent import extract_metadata
-from backend.agents.regulatory_agent import (load_gri_rules, check_gri_compliance, save_compliance_report)
-def route_to_agent (text : str):
+from backend.agents.regulatory_agent import (
+    check_all_compliance,
+    save_compliance_report,
+)
+from backend.rag.rag_suggest import generate_suggested_headers
+def route_to_agent(text: str):
+    """Run the full processing pipeline on ``text``."""
+
     cal_text = calibrate_tone(text)
-    stru_text = validate_structure(cal_text)
 
-    metadata_filename = extract_metadata(text)
+    suggestions = generate_suggested_headers(cal_text)
+    stru_text = validate_structure(cal_text, suggestions)
 
-    rules = load_gri_rules()
-    compliance_report = check_gri_compliance(stru_text, rules)
+    metadata_filename = extract_metadata(stru_text)
+
+    compliance_report = check_all_compliance(stru_text)
     compliance_filename = save_compliance_report(compliance_report)
-    overall_score = compliance_report.get("overall_score", 0)
 
-    return stru_text, metadata_filename, compliance_filename, overall_score
+    gri_score = compliance_report.get("gri_score", 0)
+    eu_csrd_score = compliance_report.get("eu_csrd_score", 0)
+    sasb_score = compliance_report.get("sasb_score", 0)
+
+    return (
+        stru_text,
+        metadata_filename,
+        compliance_filename,
+        gri_score,
+        eu_csrd_score,
+        sasb_score,
+    )

--- a/backend/routes/metadata.py
+++ b/backend/routes/metadata.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter, UploadFile, File
 from backend.file_handler import extract_text_from_file
-from backend.agents.agent_router import calibrate_tone, validate_structure
+from backend.agents.tone_agent import calibrate_tone
+from backend.agents.structure_validator import validate_structure
 from backend.agents.metadata_agent import extract_metadata
+from backend.rag.rag_suggest import generate_suggested_headers
 
 router = APIRouter()
 
@@ -9,6 +11,7 @@ router = APIRouter()
 async def extract_metadata_route(file: UploadFile = File(...)):
     raw_text = await extract_text_from_file(file)
     cal_text = calibrate_tone(raw_text)
-    stru_text = validate_structure(cal_text)
+    suggestions = generate_suggested_headers(cal_text)
+    stru_text = validate_structure(cal_text, suggestions)
     metadata_filename = extract_metadata(stru_text)
     return {"metadata_path": metadata_filename}

--- a/backend/routes/process.py
+++ b/backend/routes/process.py
@@ -8,7 +8,14 @@ router = APIRouter()
 @router.post("/process")
 async def process_file(file: UploadFile = File(...)):
     raw_text = await extract_text_from_file(file)
-    processed_text, metadata_filename, compliance_filename, overall_score = route_to_agent(raw_text)
+    (
+        processed_text,
+        metadata_filename,
+        compliance_filename,
+        gri_score,
+        eu_csrd_score,
+        sasb_score,
+    ) = route_to_agent(raw_text)
 
     pdf_filename = generate_pdf(processed_text)
     pdf_url = f"/pdfs/{pdf_filename}"
@@ -19,5 +26,7 @@ async def process_file(file: UploadFile = File(...)):
         "pdf_path": pdf_filename,
         "metadata_path": metadata_filename,
         "compliance_path": compliance_filename,
-        "overall_score": overall_score 
+        "gri_score": gri_score,
+        "eu_csrd_score": eu_csrd_score,
+        "sasb_score": sasb_score
     }


### PR DESCRIPTION
## Summary
- connect new RAG suggestions and multi-regulation compliance in `agent_router`
- update `/process` API route to return compliance scores for GRI, EU CSRD and SASB
- update metadata extraction route to include structure suggestions

## Testing
- `python -m py_compile backend/agents/agent_router.py backend/routes/process.py backend/routes/metadata.py`

------
https://chatgpt.com/codex/tasks/task_e_684955632d9c8332b606a258d51fd257