### PR TITLE
Move compliance scores to gauge meters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ regex
 requests
 spacy
 streamlit
+plotly
 tenacity==9.1.2
 tensorboard==2.16.2
 tensorboard-data-server==0.7.2


### PR DESCRIPTION
## Summary
- show ESG compliance scores using gauge meters
- add Plotly dependency for gauge visuals

## Testing
- `python -m py_compile frontend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_684965aa27188332a12503b45d1c3f76